### PR TITLE
Convert Nutrisync to run as an app on Android

### DIFF
--- a/project/odoo/nutrisync/client/android/app/src/main/AndroidManifest.xml
+++ b/project/odoo/nutrisync/client/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.nutrisync">
+
+    <application
+        android:label="nutrisync"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:allowBackup="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:label="nutrisync"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/project/odoo/nutrisync/client/android/app/src/main/res/drawable/launch_background.xml
+++ b/project/odoo/nutrisync/client/android/app/src/main/res/drawable/launch_background.xml
@@ -1,0 +1,8 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/white" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@mipmap/ic_launcher" />
+    </item>
+</layer-list>

--- a/project/odoo/nutrisync/client/android/app/src/main/res/values/strings.xml
+++ b/project/odoo/nutrisync/client/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Nutrisync</string>
+    <string name="flutter_app_name">Nutrisync Flutter App</string>
+</resources>

--- a/project/odoo/nutrisync/client/flutter_launcher_icons.yaml
+++ b/project/odoo/nutrisync/client/flutter_launcher_icons.yaml
@@ -1,0 +1,6 @@
+flutter_icons:
+  android: true
+  ios: true
+  image_path: "assets/icon/icon.png"
+  adaptive_icon_background: "assets/icon/background.png"
+  adaptive_icon_foreground: "assets/icon/foreground.png"

--- a/project/odoo/nutrisync/client/package.json
+++ b/project/odoo/nutrisync/client/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "flutter-build-apk": "flutter build apk"
   },
   "dependencies": {
     "@auth/core": "^0.37.4",
@@ -81,6 +82,8 @@
     "tailwindcss": "^3.4.15",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "flutter": "^3.10.5",
+    "flutter_launcher_icons": "^0.9.2"
   }
 }

--- a/project/odoo/nutrisync/client/src/App.tsx
+++ b/project/odoo/nutrisync/client/src/App.tsx
@@ -16,30 +16,33 @@ import { Metrics } from "./pages/Metrics"
 import { Profile } from "./pages/Profile"
 import { Integrations } from "./pages/Integrations"
 import { ProtectedRoute } from "./components/ProtectedRoute"
+import { FlutterApp } from "flutter"
 
 function App() {
   return (
     <AuthProvider>
       <ThemeProvider defaultTheme="light" storageKey="ui-theme">
-        <Router>
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-            <Route path="/forgot-password" element={<ForgotPassword />} />
-            <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
-              <Route index element={<Dashboard />} />
-              <Route path="mental-health" element={<MentalHealth />} />
-              <Route path="fitness" element={<Fitness />} />
-              <Route path="contact" element={<Contact />} />
-              <Route path="appointments" element={<Appointments />} />
-              <Route path="meditation" element={<Meditation />} />
-              <Route path="metrics" element={<Metrics />} />
-              <Route path="profile" element={<Profile />} />
-              <Route path="integrations" element={<Integrations />} />
-            </Route>
-          </Routes>
-          <Toaster />
-        </Router>
+        <FlutterApp>
+          <Router>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route path="/register" element={<Register />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
+                <Route index element={<Dashboard />} />
+                <Route path="mental-health" element={<MentalHealth />} />
+                <Route path="fitness" element={<Fitness />} />
+                <Route path="contact" element={<Contact />} />
+                <Route path="appointments" element={<Appointments />} />
+                <Route path="meditation" element={<Meditation />} />
+                <Route path="metrics" element={<Metrics />} />
+                <Route path="profile" element={<Profile />} />
+                <Route path="integrations" element={<Integrations />} />
+              </Route>
+            </Routes>
+            <Toaster />
+          </Router>
+        </FlutterApp>
       </ThemeProvider>
     </AuthProvider>
   )

--- a/project/odoo/nutrisync/client/src/main.tsx
+++ b/project/odoo/nutrisync/client/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components/ErrorBoundary.tsx'
+import { FlutterApp } from 'flutter'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <FlutterApp>
+        <App />
+      </FlutterApp>
     </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
Convert Nutrisync to run as an Android app using Flutter.

* **Add Flutter dependencies and build script:**
  - Modify `project/odoo/nutrisync/client/package.json` to add `flutter` and `flutter_launcher_icons` dependencies.
  - Add `flutter build apk` script to the `scripts` section.

* **Integrate Flutter in React components:**
  - Modify `project/odoo/nutrisync/client/src/App.tsx` to import `flutter` package and wrap the existing `App` component with `FlutterApp` component.
  - Modify `project/odoo/nutrisync/client/src/main.tsx` to import `flutter` package and wrap the existing `ReactDOM.render` call with `FlutterApp` component.

* **Add Flutter configuration files:**
  - Add `project/odoo/nutrisync/client/flutter_launcher_icons.yaml` with configuration for Flutter launcher icons.
  - Add `project/odoo/nutrisync/client/android/app/src/main/AndroidManifest.xml` with Android manifest file for Flutter app.
  - Add `project/odoo/nutrisync/client/android/app/src/main/res/values/strings.xml` with strings.xml file for Flutter app.
  - Add `project/odoo/nutrisync/client/android/app/src/main/res/drawable/launch_background.xml` with launch_background.xml file for Flutter app.
  - Add various `ic_launcher.png` files in `project/odoo/nutrisync/client/android/app/src/main/res/mipmap-*` directories for Flutter app.

